### PR TITLE
Fixed scrolling considering extra components

### DIFF
--- a/src/components/DocumentPage/ScrollingDocument.vue
+++ b/src/components/DocumentPage/ScrollingDocument.vue
@@ -73,7 +73,9 @@ export default {
      */
     onPageJump(scrollTop) {
       const actualScroll = scrollTop;
-      this.$refs.scrollingDocument.scrollTop = actualScroll - 63;
+      this.$refs.scrollingDocument.scrollTop =
+        // the 4 comes from the margin between pages
+        actualScroll - (this.$refs.scrollingDocument.offsetTop + 4);
     }
   }
 };


### PR DESCRIPTION
Fixed scrolling so it still works when there are other components in the page (such as DocumentsList), or when the Dashboard was embedded in another app.