### PR TITLE
Fix issue with annotation placeholder

### DIFF
--- a/src/components/DocumentAnnotations/Annotation.vue
+++ b/src/components/DocumentAnnotations/Annotation.vue
@@ -279,8 +279,8 @@ export default {
         newAnnotation &&
         oldAnnotation.id === this.annotation.id &&
         oldAnnotation.index === this.spanIndex &&
-        oldAnnotation.id !== newAnnotation.id &&
-        oldAnnotation.index !== newAnnotation.index
+        (oldAnnotation.id !== newAnnotation.id ||
+          oldAnnotation.index !== newAnnotation.index)
       ) {
         this.setText(
           this.isAnnotationEmpty


### PR DESCRIPTION
Sometimes, the placeholder stating to draw a box on the document was incorrectly displayed in an annotation.