### PR TITLE
Improvements & bugfixes in annotations

### DIFF
--- a/src/components/DocumentDashboard.vue
+++ b/src/components/DocumentDashboard.vue
@@ -115,11 +115,16 @@ export default {
       const { defaultViewport, $el } = this;
       if (!defaultViewport.width) return 0;
 
-      const elementsWidth =
-        (this.$refs.editView
-          ? this.$refs.editView.$el.clientWidth
-          : this.$refs.documentPages.$el.clientWidth +
-            this.$refs.annotations.$el.clientWidth) + 1;
+      let elementsWidth = 1;
+      if (this.$refs.editView) {
+        elementsWidth += this.$refs.editView.$el.clientWidth;
+      }
+      if (this.$refs.documentPages) {
+        elementsWidth += this.$refs.documentPages.$el.clientWidth;
+      }
+      if (this.$refs.annotations) {
+        elementsWidth += this.$refs.annotations.$el.clientWidth;
+      }
 
       return (
         (($el.clientWidth - elementsWidth) * PIXEL_RATIO * VIEWPORT_RATIO) /

--- a/src/components/DocumentPage/DocumentPage.vue
+++ b/src/components/DocumentPage/DocumentPage.vue
@@ -32,7 +32,7 @@
         />
 
         <template v-if="pageInVisibleRange && !editMode">
-          <v-group ref="entities" v-if="!publicView">
+          <v-group ref="entities" v-if="!publicView && !isSelectionEnabled">
             <v-rect
               v-for="(entity, index) in scaledEntities"
               :key="index"
@@ -165,7 +165,6 @@ export default {
         this.documentFocusedAnnotation.span &&
         this.documentFocusedAnnotation.span[0].page_index + 1 ===
           this.pageNumber &&
-        this.documentFocusedAnnotation.is_correct &&
         this.visiblePageRange.includes(
           this.documentFocusedAnnotation.span[0].page_index + 1
         ) &&
@@ -234,7 +233,6 @@ export default {
       if (this.annotations) {
         this.annotations.map(annotation => {
           if (
-            annotation.is_correct &&
             annotation.span.find(
               span => span.page_index + 1 === this.pageNumber
             )

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -7,7 +7,7 @@
   "upload_documents": "Laden Sie Ihre Dokumente hoch",
   "request_trial": "Fordern Sie Ihren Probezugang an",
   "warning_message": "Die KI kann nicht trainiert werden, wenn Sie den Text manuell ändern.",
-  "editing_error": "Eine Bearbeitung war nicht möglich. Bitte versuchen Sie es später erneut.",
+  "editing_error": "Editing this annotation is not possible.",
   "category": "Kategorie",
   "status": "Status",
   "preparation": "Vorbereitung",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -7,7 +7,7 @@
   "upload_documents": "Upload your own documents",
   "request_trial": "Request  trial access",
   "warning_message": "AI can’t be trained if you change the text manually.",
-  "editing_error": "Editing was not possible. Please try again later",
+  "editing_error": "Editing this annotation is not possible.",
   "category": "Category",
   "status": "Status",
   "preparation": "Preparation",


### PR DESCRIPTION
Lots of improvements in annotations on the sidebar and the document. 
Now the information on the store is updated without the need to make new requests when we update/create/delete annotations. 
Improved the handling between every states of an annotation edit. 
Fixed the empty annotations placeholder message appearing while loading.
Fixed the infinite loading that could occur sometimes.