### PR TITLE
Allow multi entity selection

### DIFF
--- a/src/components/DocumentAnnotations/AnnotationContent.vue
+++ b/src/components/DocumentAnnotations/AnnotationContent.vue
@@ -64,7 +64,11 @@ export default {
     };
   },
   computed: {
-    ...mapGetters("document", ["isAnnotationInEditMode", "pageAtIndex"]),
+    ...mapGetters("document", [
+      "isAnnotationInEditMode",
+      "pageAtIndex",
+      "getTextFromEntities",
+    ]),
     ...mapGetters("display", ["bboxToRect"]),
     ...mapGetters("selection", ["isValueArray"]),
     ...mapState("selection", ["spanSelection", "selectionEnabled"]),
@@ -73,13 +77,13 @@ export default {
       "publicView",
       "annotations",
       "newAcceptedAnnotations",
-      "selectedEntity",
+      "selectedEntities",
       "showActionError",
     ]),
     annotationText() {
       if (this.isAnnotationBeingEdited) {
-        if (this.selectedEntity) {
-          return this.selectedEntity.offset_string;
+        if (this.selectedEntities && this.selectedEntities.length > 0) {
+          return this.getTextFromEntities();
         }
         return this.$refs.contentEditable.textContent.trim();
       } else {
@@ -127,11 +131,14 @@ export default {
         this.handleCancel(true);
       }
     },
-    selectedEntity(newValue) {
+    selectedEntities(newValue) {
       if (!newValue) return;
 
-      if (this.annotation.id === this.editAnnotation.id) {
-        this.setText(newValue.offset_string);
+      if (
+        this.editAnnotation &&
+        this.annotation.id === this.editAnnotation.id
+      ) {
+        this.setText(this.getTextFromEntities());
       }
     },
     saveChanges(newValue) {
@@ -208,7 +215,7 @@ export default {
         this.$refs.contentEditable.blur();
       }
 
-      this.$store.dispatch("document/setSelectedEntity", null);
+      this.$store.dispatch("document/setSelectedEntities", null);
     },
     handlePaste(event) {
       // TODO: modify to only paste plain text

--- a/src/components/DocumentAnnotations/AnnotationRow.vue
+++ b/src/components/DocumentAnnotations/AnnotationRow.vue
@@ -137,7 +137,7 @@ export default {
       "hoveredAnnotationSet",
       "enableGroupingFeature",
       "publicView",
-      "selectedEntity",
+      "selectedEntities",
       "newAcceptedAnnotations",
       "rejectedMissingAnnotations",
       "documentId",
@@ -161,6 +161,11 @@ export default {
         this.isValueArray(this.spanSelection) &&
         this.isAnnotationInEditMode(this.annotationId())
       );
+    },
+    spanFromSelectedEntities() {
+      return this.selectedEntities.flatMap((ann) => {
+        return { ...ann.entity.original, offset_string: ann.content };
+      });
     },
     isAnnotation() {
       return (
@@ -322,7 +327,7 @@ export default {
         if (!this.isAnnotationInEditMode(this.annotationId())) return;
 
         // Check if an entity was selected instead of bbox
-        if (this.selectedEntity) {
+        if (this.selectedEntities && this.selectedEntities.length > 0) {
           return this.selectionEnabled === this.annotationId();
         } else {
           return (
@@ -403,8 +408,8 @@ export default {
           let span;
 
           // Check if editing was from selecting an entity
-          if (this.selectedEntity) {
-            span = this.selectedEntity;
+          if (this.selectedEntities && this.selectedEntities.length > 0) {
+            span = this.spanFromSelectedEntities;
           } else {
             spans = [...this.spanSelection];
             span = this.createSpan(
@@ -422,8 +427,8 @@ export default {
           // if span is NOT an array, but an object
           let span;
 
-          if (this.selectedEntity) {
-            spans[spanIndex] = { ...this.selectedEntity };
+          if (this.selectedEntities && this.selectedEntities.length > 0) {
+            spans[spanIndex] = this.spanFromSelectedEntities;
           } else if (this.spanSelection) {
             span = this.createSpan(this.spanSelection, annotationText);
 
@@ -467,6 +472,7 @@ export default {
         .finally(() => {
           this.$store.dispatch("document/resetEditAnnotation");
           this.$store.dispatch("selection/disableSelection");
+          this.$store.dispatch("document/setSelectedEntities", null);
         });
     },
     createSpan(span, annotationText) {
@@ -485,8 +491,8 @@ export default {
       let annotationToCreate;
       let span;
 
-      if (this.selectedEntity) {
-        span = [this.selectedEntity];
+      if (this.selectedEntities && this.selectedEntities.length > 0) {
+        span = this.spanFromSelectedEntities;
       } else {
         span = this.spanSelection;
       }
@@ -540,6 +546,7 @@ export default {
       this.$store.dispatch("document/resetEditAnnotation");
       if (this.selectionEnabled) {
         this.$store.dispatch("selection/disableSelection");
+        this.$store.dispatch("document/setSelectedEntities", null);
       }
     },
     enableLoading(annotations) {

--- a/src/components/DocumentPage/DocumentPage.vue
+++ b/src/components/DocumentPage/DocumentPage.vue
@@ -248,7 +248,7 @@ export default {
       "editAnnotation",
       "selectedDocument",
       "publicView",
-      "selectedEntity",
+      "selectedEntities",
     ]),
     ...mapState("edit", ["editMode"]),
     ...mapGetters("display", [
@@ -287,6 +287,11 @@ export default {
     },
     scale() {
       this.closeNewAnnotation();
+    },
+    selectedEntities(newValue) {
+      if (!newValue) {
+        this.closeNewAnnotation();
+      }
     },
   },
 
@@ -467,8 +472,6 @@ export default {
             fillColor = "#67E9B7";
           }
         });
-      } else if (this.selectedEntity === entity.original) {
-        fillColor = "#67E9B7";
       } else {
         fillColor = "transparent";
       }
@@ -568,36 +571,38 @@ export default {
       // Check if we are creating a new Annotation
       // or if we are ediitng an existing or empty one
 
-      if (!this.isSelectionEnabled) {
-        const entityToAdd = {
-          entity,
-          content: entity.original.offset_string,
-        };
+      const entityToAdd = {
+        entity,
+        content: entity.original.offset_string,
+      };
 
-        let found;
+      let found;
 
-        if (this.newAnnotation) {
-          found = this.newAnnotation.find(
-            (ann) =>
-              ann.entity.scaled.width === entityToAdd.entity.scaled.width &&
-              ann.content === entityToAdd.content
-          );
-        }
-
-        if (found) {
-          this.newAnnotation = this.newAnnotation.filter(
-            (ann) =>
-              ann.entity.scaled.width !== entityToAdd.entity.scaled.width &&
-              ann.content !== entityToAdd.content
-          );
-        } else {
-          this.newAnnotation.push(entityToAdd);
-        }
-        return;
+      if (this.newAnnotation) {
+        found = this.newAnnotation.find(
+          (ann) =>
+            ann.entity.scaled.width === entityToAdd.entity.scaled.width &&
+            ann.content === entityToAdd.content
+        );
       }
 
-      if (!this.isSelecting) {
-        this.$store.dispatch("document/setSelectedEntity", entity.original);
+      if (found) {
+        this.newAnnotation = this.newAnnotation.filter(
+          (ann) =>
+            ann.entity.scaled.width !== entityToAdd.entity.scaled.width &&
+            ann.content !== entityToAdd.content
+        );
+      } else {
+        this.newAnnotation.push(entityToAdd);
+      }
+
+      if (this.newAnnotation.length > 0) {
+        this.$store.dispatch(
+          "document/setSelectedEntities",
+          this.newAnnotation
+        );
+      } else {
+        this.$store.dispatch("document/setSelectedEntities", null);
       }
     },
 

--- a/src/components/DocumentPage/NewAnnotation.vue
+++ b/src/components/DocumentPage/NewAnnotation.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="annotation-popup" :style="{ left: `${left}px`, top: `${top}px` }">
-    <input v-model="getSelectedContent" class="popup-input" type="text" />
+    <input v-model="textFromEntities" class="popup-input" type="text" />
     <b-dropdown
       v-model="selectedSet"
       aria-role="list"
@@ -97,7 +97,7 @@
         type="is-primary"
         class="popup-button"
         :label="$t('save')"
-        :disabled="loading || !selectedContent || !selectedLabel"
+        :disabled="loading || !getTextFromEntities || !selectedLabel"
         @click.prevent="save"
       />
     </div>
@@ -135,7 +135,6 @@ export default {
       selectedLabel: null,
       selectedSet: null,
       labels: null,
-      selectedContent: [],
       loading: false,
       isAnnSetModalShowing: false,
       setsList: [],
@@ -146,6 +145,7 @@ export default {
     ...mapGetters("document", [
       "numberOfAnnotationSetGroup",
       "labelsFilteredForAnnotationCreation",
+      "getTextFromEntities",
     ]),
     top() {
       const top = this.newAnnotation[0].entity.scaled.y - heightOfPopup; // subtract the height of the popup plus some margin
@@ -172,18 +172,14 @@ export default {
         return left > 0 ? left : 0;
       }
     },
-    getSelectedContent() {
-      return this.selectedContent.join(" ");
+    textFromEntities() {
+      return this.getTextFromEntities();
     },
   },
   watch: {
     selectedSet(newValue) {
       this.selectedLabel = null;
       this.labels = this.labelsFilteredForAnnotationCreation(newValue);
-    },
-
-    newAnnotation(newValue) {
-      this.updateSelectedContent(newValue);
     },
   },
   mounted() {
@@ -193,21 +189,12 @@ export default {
       // prevent click propagation when opening the popup
       document.body.addEventListener("click", this.clickOutside);
     }, 200);
-
-    this.updateSelectedContent(this.newAnnotation);
   },
   destroyed() {
     document.body.removeEventListener("click", this.clickOutside);
   },
   methods: {
-    updateSelectedContent(annotation) {
-      this.selectedContent = [];
-      annotation.map((ann) => {
-        this.selectedContent.push(ann.content);
-      });
-    },
     close() {
-      this.selectedContent = [];
       this.$emit("close");
     },
     save() {

--- a/src/store/document.js
+++ b/src/store/document.js
@@ -26,7 +26,7 @@ const state = {
   hoveredAnnotationSet: null,
   finishedReview: false,
   newAcceptedAnnotations: null,
-  selectedEntity: null,
+  selectedEntities: null,
 };
 
 const getters = {
@@ -377,6 +377,14 @@ const getters = {
       state.publicView
     );
   },
+
+  getTextFromEntities: (state) => () => {
+    return state.selectedEntities
+      .map((entity) => {
+        return entity.content;
+      })
+      .join(" ");
+  },
 };
 
 const actions = {
@@ -462,8 +470,8 @@ const actions = {
   setNewAcceptedAnnotations: ({ commit }, annotations) => {
     commit("SET_NEW_ACCEPTED_ANNOTATIONS", annotations);
   },
-  setSelectedEntity: ({ commit }, entity) => {
-    commit("SET_SELECTED_ENTITY", entity);
+  setSelectedEntities: ({ commit }, entities) => {
+    commit("SET_SELECTED_ENTITIES", entities);
   },
 
   /**
@@ -991,8 +999,8 @@ const mutations = {
   SET_NEW_ACCEPTED_ANNOTATIONS: (state, annotations) => {
     state.newAcceptedAnnotations = annotations;
   },
-  SET_SELECTED_ENTITY: (state, entity) => {
-    state.selectedEntity = entity;
+  SET_SELECTED_ENTITIES: (state, entities) => {
+    state.selectedEntities = entities;
   },
 };
 

--- a/src/store/selection.js
+++ b/src/store/selection.js
@@ -8,26 +8,26 @@ const state = {
   selection: {
     pageNumber: null,
     start: null,
-    end: null
+    end: null,
   },
   isSelecting: false,
   spanSelection: null,
-  selectionEnabled: null
+  selectionEnabled: null,
 };
 
 const getters = {
-  isSelectionEnabled: state => {
+  isSelectionEnabled: (state) => {
     return state.selectionEnabled;
   },
-  getSelectionForPage: state => pageNumber => {
+  getSelectionForPage: (state) => (pageNumber) => {
     if (state.selection.pageNumber === pageNumber) {
       return state.selection;
     }
     return null;
   },
-  isValueArray: () => value => {
+  isValueArray: () => (value) => {
     return Array.isArray(value);
-  }
+  },
 };
 
 const actions = {
@@ -43,22 +43,22 @@ const actions = {
     commit("SET_SPAN_SELECTION", null);
   },
 
-  startSelection: ({ commit, dispatch }, { pageNumber, start }) => {
+  startSelection: ({ commit }, { pageNumber, start }) => {
     commit("START_SELECTION", {
       pageNumber,
-      start
+      start,
     });
-
-    dispatch("document/setSelectedEntity", null, { root: true });
   },
 
-  moveSelection: ({ commit, state }, points) => {
+  moveSelection: ({ commit, state, dispatch }, points) => {
     // only apply when we have a large enough selection, otherwise we risk counting misclicks
     const xDiff = Math.abs(state.selection.start.x - points.end.x);
     const yDiff = Math.abs(state.selection.start.y - points.end.y);
     if (xDiff > 5 && yDiff > 5) {
       commit("MOVE_SELECTION", points);
     }
+
+    dispatch("document/setSelectedEntities", null, { root: true });
   },
 
   endSelection: ({ commit, state }, end) => {
@@ -89,9 +89,9 @@ const actions = {
 
   getTextFromBboxes: ({ commit, rootState }, box) => {
     return HTTP.post(`documents/${rootState.document.documentId}/bbox/`, {
-      span: [box]
+      span: [box],
     })
-      .then(response => {
+      .then((response) => {
         if (response.data.span.length && response.data.span.length > 0) {
           /**
            * If we have a non-empty bboxes list, we assume there
@@ -110,13 +110,13 @@ const actions = {
           commit("SET_SPAN_SELECTION", box);
         }
       })
-      .catch(error => {
+      .catch((error) => {
         alert("Could not fetch the selected text from the backend");
       });
   },
   setSpanSelection: ({ commit }, span) => {
     commit("SET_SPAN_SELECTION", span);
-  }
+  },
 };
 
 const mutations = {
@@ -142,7 +142,7 @@ const mutations = {
     state.selection.end = end;
     state.isSelecting = false;
   },
-  RESET_SELECTION: state => {
+  RESET_SELECTION: (state) => {
     state.isSelecting = false;
     state.selection.pageNumber = null;
     state.selection.start = null;
@@ -153,7 +153,7 @@ const mutations = {
   },
   SET_SELECTION: (state, selection) => {
     state.selection = selection;
-  }
+  },
 };
 
 export default {
@@ -161,5 +161,5 @@ export default {
   state,
   getters,
   actions,
-  mutations
+  mutations,
 };


### PR DESCRIPTION
Allow users to select multiple entities at once when editing empty or filled annotations, as an alternative to the bounding box